### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # GitFlexibleListView
-####Author:Ezreal Wang
-####Blog:[http://blog.csdn.net/ddwhan0123](http://blog.csdn.net/ddwhan0123) 
-####QQ:526357367
-####WeChat ID:<br>![WeChatID](https://github.com/ddwhan0123/SoyiGit/blob/master/Soyi/WeChatID.JPG "二维码")
-####效果图:<br>![WeChatID](https://github.com/ddwhan0123/GitFlexibleListView/blob/master/FlexibleListView/coco1.gif "效果图")
+#### Author:Ezreal Wang
+#### Blog:[http://blog.csdn.net/ddwhan0123](http://blog.csdn.net/ddwhan0123) 
+#### QQ:526357367
+#### WeChat ID:<br>![WeChatID](https://github.com/ddwhan0123/SoyiGit/blob/master/Soyi/WeChatID.JPG "二维码")
+#### 效果图:<br>![WeChatID](https://github.com/ddwhan0123/GitFlexibleListView/blob/master/FlexibleListView/coco1.gif "效果图")
 <br>
 Anim被Gif软件给吃了，实际效果只能run了自己看了。。抱歉。


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
